### PR TITLE
Added timestamp metadatas to post processing frames

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -491,11 +491,6 @@ namespace librealsense
         return additional_data.frame_number;
     }
 
-    std::array<uint8_t, MAX_META_DATA_SIZE> frame::get_metadata_blob() const
-    {
-        return additional_data.metadata_blob;
-    }
-
     rs2_time_t frame::get_frame_system_time() const
     {
         return additional_data.system_time;

--- a/src/archive.h
+++ b/src/archive.h
@@ -80,7 +80,6 @@ namespace librealsense
         rs2_timestamp_domain get_frame_timestamp_domain() const override;
         void set_timestamp(double new_ts) override { additional_data.timestamp = new_ts; }
         unsigned long long get_frame_number() const override;
-        std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const override;
         void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) override
         {
             additional_data.timestamp_domain = timestamp_domain;
@@ -205,10 +204,7 @@ namespace librealsense
         {
             return first()->get_sensor();
         }
-        std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const override
-        {
-            return first()->get_metadata_blob();
-        }
+
     };
 
     MAP_EXTENSION(RS2_EXTENSION_COMPOSITE_FRAME, librealsense::composite_frame);

--- a/src/archive.h
+++ b/src/archive.h
@@ -16,46 +16,46 @@ namespace librealsense
     class frame;
 }
 
-struct frame_additional_data
-{
-    rs2_time_t timestamp = 0;
-    unsigned long long frame_number = 0;
-    rs2_timestamp_domain timestamp_domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK;
-    rs2_time_t      system_time = 0;
-    rs2_time_t      frame_callback_started = 0;
-    uint32_t        metadata_size = 0;
-    bool            fisheye_ae_mode = false;
-    std::array<uint8_t,MAX_META_DATA_SIZE> metadata_blob;
-    rs2_time_t      backend_timestamp = 0;
-    rs2_time_t last_timestamp = 0;
-    unsigned long long last_frame_number = 0;
-
-    frame_additional_data() {};
-
-    frame_additional_data(double in_timestamp,
-        unsigned long long in_frame_number,
-        double in_system_time,
-        uint8_t md_size,
-        const uint8_t* md_buf,
-        double backend_time,
-        rs2_time_t last_timestamp,
-        unsigned long long last_frame_number)
-        : timestamp(in_timestamp),
-          frame_number(in_frame_number),
-          system_time(in_system_time),
-          metadata_size(md_size),
-          backend_timestamp(backend_time),
-          last_timestamp(last_timestamp),
-          last_frame_number(last_frame_number)
-    {
-        // Copy up to 255 bytes to preserve metadata as raw data
-        if (metadata_size)
-            std::copy(md_buf,md_buf+ std::min(md_size,MAX_META_DATA_SIZE),metadata_blob.begin());
-    }
-};
-
 namespace librealsense
 {
+    struct frame_additional_data
+    {
+        rs2_time_t timestamp = 0;
+        unsigned long long frame_number = 0;
+        rs2_timestamp_domain timestamp_domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK;
+        rs2_time_t      system_time = 0;
+        rs2_time_t      frame_callback_started = 0;
+        uint32_t        metadata_size = 0;
+        bool            fisheye_ae_mode = false;
+        std::array<uint8_t, MAX_META_DATA_SIZE> metadata_blob;
+        rs2_time_t      backend_timestamp = 0;
+        rs2_time_t last_timestamp = 0;
+        unsigned long long last_frame_number = 0;
+
+        frame_additional_data() {};
+
+        frame_additional_data(double in_timestamp,
+            unsigned long long in_frame_number,
+            double in_system_time,
+            uint8_t md_size,
+            const uint8_t* md_buf,
+            double backend_time,
+            rs2_time_t last_timestamp,
+            unsigned long long last_frame_number)
+            : timestamp(in_timestamp),
+            frame_number(in_frame_number),
+            system_time(in_system_time),
+            metadata_size(md_size),
+            backend_timestamp(backend_time),
+            last_timestamp(last_timestamp),
+            last_frame_number(last_frame_number)
+        {
+            // Copy up to 255 bytes to preserve metadata as raw data
+            if (metadata_size)
+                std::copy(md_buf, md_buf + std::min(md_size, MAX_META_DATA_SIZE), metadata_blob.begin());
+        }
+    };
+
     typedef std::map<rs2_frame_metadata_value, std::shared_ptr<md_attribute_parser_base>> metadata_parser_map;
 
     // Define a movable but explicitly noncopyable buffer type to hold our frame data
@@ -84,7 +84,7 @@ namespace librealsense
         {
             additional_data.timestamp_domain = timestamp_domain;
         }
-
+        frame_additional_data get_frame_additional_data() const override { return additional_data; }
         rs2_time_t get_frame_system_time() const override;
 
         std::shared_ptr<stream_profile_interface> get_stream() const override { return stream; }
@@ -204,7 +204,10 @@ namespace librealsense
         {
             return first()->get_sensor();
         }
-
+        frame_additional_data get_frame_additional_data() const override 
+        { 
+            return first()->get_frame_additional_data();
+        }
     };
 
     MAP_EXTENSION(RS2_EXTENSION_COMPOSITE_FRAME, librealsense::composite_frame);

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -74,7 +74,6 @@ namespace librealsense
 
         virtual void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) = 0;
         virtual rs2_time_t get_frame_system_time() const = 0;
-        virtual std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const = 0;
         virtual std::shared_ptr<stream_profile_interface> get_stream() const = 0;
         virtual void set_stream(std::shared_ptr<stream_profile_interface> sp) = 0;
 

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -17,6 +17,7 @@ namespace librealsense
     class sensor_interface;
     class archive_interface;
     class device_interface;
+    struct frame_additional_data;
 
     class sensor_part
     {
@@ -71,7 +72,7 @@ namespace librealsense
         virtual rs2_timestamp_domain get_frame_timestamp_domain() const = 0;
         virtual void set_timestamp(double new_ts) = 0;
         virtual unsigned long long get_frame_number() const = 0;
-
+        virtual frame_additional_data get_frame_additional_data() const = 0;
         virtual void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) = 0;
         virtual rs2_time_t get_frame_system_time() const = 0;
         virtual std::shared_ptr<stream_profile_interface> get_stream() const = 0;

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -90,7 +90,6 @@ namespace librealsense
             vf = static_cast<video_frame*>(original);
         }
 
-        frame_additional_data data = vf->additional_data;
         auto width = new_width;
         auto height = new_height;
         auto bpp = new_bpp * 8;
@@ -120,6 +119,7 @@ namespace librealsense
             height = vf->get_height();
         }
 
+        frame_additional_data data = ((frame*)original)->additional_data;
         auto res = _actual_source.alloc_frame(frame_type, stride * height, data, true);
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = static_cast<video_frame*>(res);

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -90,13 +90,7 @@ namespace librealsense
             vf = static_cast<video_frame*>(original);
         }
 
-        frame_additional_data data{};
-        data.frame_number = original->get_frame_number();
-        data.timestamp = original->get_frame_timestamp();
-        data.timestamp_domain = original->get_frame_timestamp_domain();
-        data.metadata_size = 0;
-        data.system_time = _actual_source.get_time();
-        data.metadata_blob = original->get_metadata_blob();
+        frame_additional_data data = vf->additional_data;
         auto width = new_width;
         auto height = new_height;
         auto bpp = new_bpp * 8;

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -119,7 +119,7 @@ namespace librealsense
             height = vf->get_height();
         }
 
-        frame_additional_data data = ((frame*)original)->additional_data;
+        frame_additional_data data = original->get_frame_additional_data();
         auto res = _actual_source.alloc_frame(frame_type, stride * height, data, true);
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = static_cast<video_frame*>(res);

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -531,6 +531,7 @@ TEST_CASE("Sync start stop", "[live]") {
         REQUIRE(image.get_height() == other_video.height());
     }
 }
+
 TEST_CASE("Device metadata enumerates correctly", "[live]")
 {
     rs2::context ctx;

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4670,9 +4670,7 @@ TEST_CASE("Post-Processing Filters metadata validation", "[live][post-processing
         else
         {
             REQUIRE(pipeline_default_configurations.at(PID).streams.size() > 0);
-
             REQUIRE_NOTHROW(pipe.start(cfg));
-
             for (auto i = 0; i < 30; i++)
             {
                 for (auto filter : filters)
@@ -4686,6 +4684,7 @@ TEST_CASE("Post-Processing Filters metadata validation", "[live][post-processing
                     compare_frame_md(depth, filtered_depth);
                 }
             }
+            REQUIRE_NOTHROW(pipe.stop());
         }
     }
 }

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -179,7 +179,6 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
         {
             CAPTURE(ppf_test.first);
             CAPTURE(ppf_test.second);
-
             WARN("PPF test " << ppf_test.first << "[" << ppf_test.second << "]");
 
             // Load the data from configuration and raw frame files

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -143,27 +143,6 @@ bool validate_ppf_results(rs2::frame origin_depth, rs2::frame result_depth, cons
     return profile_diffs("./Filterstransform.txt", diff2ref, 0.f, 0, frame_idx);
 }
 
-void compare_frame_md(rs2::frame origin_depth, rs2::frame result_depth)
-{
-    for (auto i = 0; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
-    {
-        bool origin_supported = origin_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
-        bool result_supported = result_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
-        REQUIRE(origin_supported == result_supported);
-        if (origin_supported && result_supported)
-        {
-            //FRAME_TIMESTAMP and SENSOR_TIMESTAMP metadatas are not included in post proccesing frames,
-            //TIME_OF_ARRIVAL continues to increase  after post proccesing
-            if (i == RS2_FRAME_METADATA_FRAME_TIMESTAMP ||
-                i == RS2_FRAME_METADATA_SENSOR_TIMESTAMP ||
-                i == RS2_FRAME_METADATA_TIME_OF_ARRIVAL) continue;
-            rs2_metadata_type origin_val = origin_depth.get_frame_metadata((rs2_frame_metadata_value)i);
-            rs2_metadata_type result_val = result_depth.get_frame_metadata((rs2_frame_metadata_value)i);
-            REQUIRE(origin_val == result_val);
-        }
-    }
-}
-
 // The test is intended to check the results of filters applied on a sequence of frames, specifically the temporal filter
 // that preserves an internal state. The test utilizes rosbag recordings
 TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post-processing-filters]")
@@ -258,7 +237,6 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
 
                 // Compare the resulted frame versus input
                 validate_ppf_results(depth, filtered_depth, test_cfg, i);
-                compare_frame_md(depth, filtered_depth);
             }
         }
     }


### PR DESCRIPTION
-At post processing frames creation all the additional data of the original frame is copied.
-Added live test to check that the metadata of the original frame is equal to the metadata of the generated post processing frame.