### PR TITLE
Added functionality of no throw wait_for_frame

### DIFF
--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -92,7 +92,7 @@ EXPORTS
     rs2_delete_frame_queue
     rs2_wait_for_frame
     rs2_poll_for_frame
-	rs2_try_wait_for_frame
+    rs2_try_wait_for_frame
     rs2_enqueue_frame
     rs2_flush_queue
 
@@ -224,7 +224,7 @@ EXPORTS
     rs2_pipeline_stop
     rs2_pipeline_wait_for_frames
     rs2_pipeline_poll_for_frames
-	rs2_pipeline_try_wait_for_frames
+    rs2_pipeline_try_wait_for_frames
     rs2_delete_pipeline
     rs2_pipeline_start
     rs2_pipeline_start_with_config

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -92,6 +92,7 @@ EXPORTS
     rs2_delete_frame_queue
     rs2_wait_for_frame
     rs2_poll_for_frame
+	rs2_try_wait_for_frame
     rs2_enqueue_frame
     rs2_flush_queue
 
@@ -223,6 +224,7 @@ EXPORTS
     rs2_pipeline_stop
     rs2_pipeline_wait_for_frames
     rs2_pipeline_poll_for_frames
+	rs2_pipeline_try_wait_for_frames
     rs2_delete_pipeline
     rs2_pipeline_start
     rs2_pipeline_start_with_config

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3169,7 +3169,8 @@ namespace rs2
                 if(viewer.synchronization_enable)
                 {
                     auto index = 0;
-                    while (syncer_queue.poll_for_frame(&frm) && ++index <= syncer_queue.capacity())
+                    while (syncer_queue.try_wait_for_frame(&frm, 30) && ++index <= syncer_queue.capacity())
+                    //while (syncer_queue.poll_for_frame(&frm) && ++index <= syncer_queue.capacity())
                     {
                         processing_block.invoke(frm);
                     }
@@ -3184,7 +3185,8 @@ namespace rs2
                     for (auto&& q : frames_queue_local)
                     {
                         frame frm;
-                        if (q.second.poll_for_frame(&frm))
+                        if (q.second.try_wait_for_frame(&frm, 30))
+                        //if (q.second.poll_for_frame(&frm))
                         {
                             processing_block.invoke(frm);
                         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3170,7 +3170,6 @@ namespace rs2
                 {
                     auto index = 0;
                     while (syncer_queue.try_wait_for_frame(&frm, 30) && ++index <= syncer_queue.capacity())
-                    //while (syncer_queue.poll_for_frame(&frm) && ++index <= syncer_queue.capacity())
                     {
                         processing_block.invoke(frm);
                     }
@@ -3186,7 +3185,6 @@ namespace rs2
                     {
                         frame frm;
                         if (q.second.try_wait_for_frame(&frm, 30))
-                        //if (q.second.poll_for_frame(&frm))
                         {
                             processing_block.invoke(frm);
                         }

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -73,6 +73,7 @@ extern "C" {
     */
     int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
+    int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error);
 
     /**
     * Delete a pipeline instance.

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -73,6 +73,21 @@ extern "C" {
     */
     int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
+    /**
+    * Wait until a new set of frames becomes available.
+    * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+    * The method blocks the calling thread, and fetches the latest unread frames set.
+    * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
+    * as fast as the device frame rate.
+    * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
+    * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
+    * are retained.
+    * \param[in] pipe the pipeline
+    * \param[in] timeout_ms   Max time in milliseconds to wait until a frame becomes available
+    * \param[out] output_frame frame handle to be released using rs2_release_frame
+    * \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return true if new frame was stored to output_frame
+    */
     int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error);
 
     /**

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -82,9 +82,9 @@ extern "C" {
     * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
     * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
     * are retained.
-    * \param[in] pipe the pipeline
-    * \param[in] timeout_ms   Max time in milliseconds to wait until a frame becomes available
-    * \param[out] output_frame frame handle to be released using rs2_release_frame
+    * \param[in] pipe           the pipeline
+    * \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+    * \param[out] output_frame  frame handle to be released using rs2_release_frame
     * \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return true if new frame was stored to output_frame
     */

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -117,7 +117,7 @@ void rs2_delete_frame_queue(rs2_frame_queue* queue);
 /**
 * wait until new frame becomes available in the queue and dequeue it
 * \param[in] queue the frame queue data structure
-* \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
+* \param[in] timeout_ms   max time in milliseconds to wait until an exception will be thrown
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return frame handle to be released using rs2_release_frame
 */
@@ -134,10 +134,10 @@ int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_err
 
 /**
 * wait until new frame becomes available in the queue and dequeue it
-* \param[in] queue the frame queue data structure
-* \param[in] timeout_ms   Max time in milliseconds to wait until a frame becomes available
-* \param[out] output_frame frame handle to be released using rs2_release_frame
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \param[in] queue          the frame queue data structure
+* \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+* \param[out] output_frame  frame handle to be released using rs2_release_frame
+* \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return true if new frame was stored to output_frame
 */
 int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error);

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -117,6 +117,7 @@ void rs2_delete_frame_queue(rs2_frame_queue* queue);
 /**
 * wait until new frame becomes available in the queue and dequeue it
 * \param[in] queue the frame queue data structure
+* \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return frame handle to be released using rs2_release_frame
 */
@@ -131,6 +132,14 @@ rs2_frame* rs2_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, r
 */
 int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_error** error);
 
+/**
+* wait until new frame becomes available in the queue and dequeue it
+* \param[in] queue the frame queue data structure
+* \param[in] timeout_ms   Max time in milliseconds to wait until a frame becomes available
+* \param[out] output_frame frame handle to be released using rs2_release_frame
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \return true if new frame was stored to output_frame
+*/
 int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error);
 
 /**

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -131,6 +131,8 @@ rs2_frame* rs2_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, r
 */
 int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_error** error);
 
+int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error);
+
 /**
 * enqueue new frame into a queue
 * \param[in] frame frame handle to enqueue (this operation passed ownership to the queue)

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -471,6 +471,20 @@ namespace rs2
             return res > 0;
         }
 
+        bool try_wait_for_frames(frameset* f, unsigned int timeout_ms = 5000) const
+        {
+            if (!f)
+            {
+                throw std::invalid_argument("null frameset");
+            }
+            rs2_error* e = nullptr;
+            rs2_frame* frame_ref = nullptr;
+            auto res = rs2_pipeline_try_wait_for_frames(_pipeline.get(), &frame_ref, timeout_ms, &e);
+            error::handle(e);
+            if (res) *f = frameset(frame(frame_ref));
+            return res > 0;
+        }
+
         /**
         * Return the active device and streams profiles, used by the pipeline.
         * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -241,6 +241,18 @@ namespace rs2
             if (res) *output = f;
             return res > 0;
         }
+
+        template<typename T>
+        typename std::enable_if<std::is_base_of<rs2::frame, T>::value, bool>::type try_wait_for_frame(T* output, unsigned int timeout_ms = 5000) const
+        {
+            rs2_error* e = nullptr;
+            rs2_frame* frame_ref = nullptr;
+            auto res = rs2_try_wait_for_frame(_queue.get(), timeout_ms, &frame_ref, &e);
+            error::handle(e);
+            frame f{ frame_ref };
+            if (res) *output = f;
+            return res > 0;
+        }
         /**
         * Does the same thing as enqueue function.
         */
@@ -385,6 +397,23 @@ namespace rs2
         {
             frame result;
             if (_results.poll_for_frame(&result))
+            {
+                *fs = frameset(result);
+                return true;
+            }
+            return false;
+        }
+
+        /**
+        * Wait until coherent set of frames becomes available
+        * \param[in] timeout_ms   Max time in milliseconds to wait until an available frame
+        * \param[out] fs      New coherent frame-set
+        * \return true if new frame-set was stored to result
+        */
+        bool try_wait_for_frames(frameset* fs, unsigned int timeout_ms = 5000) const
+        {
+            frame result;
+            if (_results.try_wait_for_frame(&result, timeout_ms))
             {
                 *fs = frameset(result);
                 return true;

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -406,8 +406,8 @@ namespace rs2
 
         /**
         * Wait until coherent set of frames becomes available
-        * \param[in] timeout_ms   Max time in milliseconds to wait until an available frame
-        * \param[out] fs      New coherent frame-set
+        * \param[in] timeout_ms     Max time in milliseconds to wait until an available frame
+        * \param[out] fs            New coherent frame-set
         * \return true if new frame-set was stored to result
         */
         bool try_wait_for_frames(frameset* fs, unsigned int timeout_ms = 5000) const

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -619,6 +619,19 @@ namespace librealsense
         return false;
     }
 
+    bool pipeline::try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms)
+    {
+        try
+        {
+            *frame = wait_for_frames(timeout_ms);
+        }
+        catch (const std::runtime_error& e)
+        {
+            return false;
+        }
+        return true;
+    }
+
     std::shared_ptr<device_interface> pipeline::wait_for_device(const std::chrono::milliseconds& timeout, const std::string& serial)
     {
         // Pipeline's device selection shall be deterministic

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -52,7 +52,7 @@ namespace librealsense
         std::shared_ptr<pipeline_profile> get_active_profile() const;
         frame_holder wait_for_frames(unsigned int timeout_ms = 5000);
         bool poll_for_frames(frame_holder* frame);
-
+        bool try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms);
         //Non top level API
         std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             const std::string& serial = "");


### PR DESCRIPTION
-Added API of try_wait_for_frame/s to frame_queue, syncer and pipeline.
 The function has the same functionality as wait_for_frame except in case of timeout try_wait_for_frame 
 returns false instead of throwing exception.
-Fixed bug of high CPU utilization in realsense-viewer

Tracked on: DSO-9381
